### PR TITLE
Add bitcode to produced libraries

### DIFF
--- a/PDFWriter3_6/CMakeLists.txt
+++ b/PDFWriter3_6/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(PDFHUMMUS)
 cmake_minimum_required (VERSION 2.6)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fembed-bitcode")
 
 if(NOT PDFHUMMUS_NO_DCT)
 	ADD_SUBDIRECTORY(LibJpeg)


### PR DESCRIPTION
Archiving with bitcode enabled requires all static libraries to be built with it enabled. So this embeds bitcode on the `.a` resulting from the build